### PR TITLE
Fix Scrolling Issue

### DIFF
--- a/src/routes/stations/[crs]/+layout.svelte
+++ b/src/routes/stations/[crs]/+layout.svelte
@@ -367,5 +367,8 @@
 		.board:not(.board-only) {
 			display: none;
 		}
+		.root > :global(*) {
+			overflow: visible;
+		}
 	}
 </style>

--- a/src/routes/stations/[crs]/+layout.svelte
+++ b/src/routes/stations/[crs]/+layout.svelte
@@ -370,5 +370,8 @@
 		.root > :global(*) {
 			overflow: visible;
 		}
+		.root {
+			display: unset;
+		}
 	}
 </style>


### PR DESCRIPTION
On iPhone Safari, the URL bar doesn't disappear when it is scrolled down to the bottom so the last rows are not visible. This fixes it. 

Sorry, this might not be the best way and might cause other scrolling issues but I don't really know CSS but at least it works in my limited testing.

## Before
![60ec0224-65cb-474f-af22-ae8e2e821f15](https://github.com/Gaelan/yadfe/assets/40887572/adf0c3d5-a983-48d8-a8ca-aa6c7ae5b7e6)
## After
![3994d1f8-9802-413c-9fed-97c4b203cd72](https://github.com/Gaelan/yadfe/assets/40887572/626629f8-db4f-4f24-8838-b86b254c2684)
