### PR TITLE
Implement filtering by previous and subsequent station calls

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,20 @@ export type HuxleyStationService = HuxleyTimes & {
 		via: string | null;
 	}[];
 
+	previousLocations:
+		| {
+				locationName: string;
+				crs: string;
+		  }[]
+		| null;
+
+	subsequentLocations:
+		| {
+				locationName: string;
+				crs: string;
+		  }[]
+		| null;
+
 	platform: string;
 	operator: string;
 	activities: string;
@@ -87,3 +101,8 @@ export type HuxleyDepartures = {
 	crs: string;
 	stationManagerCode: string;
 };
+
+export type HuxleyStations = {
+	crsCode: string;
+	stationName: string;
+}[];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
-import type { HuxleyTimes } from './types';
+import type { HuxleyStations, HuxleyTimes } from './types';
 
 export function getScheduledTime(train: HuxleyTimes) {
 	let time;
@@ -64,4 +64,39 @@ export function getActualArrivalTime(train: HuxleyTimes) {
 
 export function parseTime(time: string) {
 	return Temporal.ZonedDateTime.from(time + '[Europe/London]');
+}
+
+export function filterStations(stations: HuxleyStations, search: string) {
+	return stations
+		.filter((station) => {
+			return (
+				station.stationName.toLowerCase().includes(search) ||
+				station.crsCode.toLowerCase().includes(search)
+			);
+		})
+		.sort((a, b) => {
+			const aCrs = a.crsCode.toLowerCase();
+			const bCrs = b.crsCode.toLowerCase();
+			const aName = a.stationName.toLowerCase();
+			const bName = b.stationName.toLowerCase();
+			if (aCrs.startsWith(search) && !bCrs.startsWith(search)) {
+				return -1;
+			}
+			if (bCrs.startsWith(search) && !aCrs.startsWith(search)) {
+				return 1;
+			}
+			if (aName.startsWith(search) && !bName.startsWith(search)) {
+				return -1;
+			}
+			if (bName.startsWith(search) && !aName.startsWith(search)) {
+				return 1;
+			}
+			if (aName < bName) {
+				return -1;
+			}
+			if (bName > aName) {
+				return 1;
+			}
+			return 0;
+		});
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import type { FormEventHandler } from 'svelte/elements';
 	import type { HuxleyStations } from './+page.js';
+	import { filterStations } from '$lib/utils.js';
 
 	export let data;
 
@@ -13,38 +14,7 @@
 		if (search == '') {
 			results = data.stations;
 		} else {
-			results = data.stations
-				.filter((station) => {
-					return (
-						station.stationName.toLowerCase().includes(search) ||
-						station.crsCode.toLowerCase().includes(search)
-					);
-				})
-				.sort((a, b) => {
-					const aCrs = a.crsCode.toLowerCase();
-					const bCrs = b.crsCode.toLowerCase();
-					const aName = a.stationName.toLowerCase();
-					const bName = b.stationName.toLowerCase();
-					if (aCrs.startsWith(search) && !bCrs.startsWith(search)) {
-						return -1;
-					}
-					if (bCrs.startsWith(search) && !aCrs.startsWith(search)) {
-						return 1;
-					}
-					if (aName.startsWith(search) && !bName.startsWith(search)) {
-						return -1;
-					}
-					if (bName.startsWith(search) && !aName.startsWith(search)) {
-						return 1;
-					}
-					if (aName < bName) {
-						return -1;
-					}
-					if (bName > aName) {
-						return 1;
-					}
-					return 0;
-				});
+			results = filterStations(data.stations, search);
 		}
 	};
 

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,4 +1,4 @@
-export type HuxleyStations = { crsCode: string; stationName: string }[];
+import type { HuxleyStations } from '$lib/types.js';
 
 export async function load({ fetch }) {
 	const data: HuxleyStations = await (await fetch(`https://huxley2.azurewebsites.net/crs`)).json();


### PR DESCRIPTION
The previous calls filter doesn't currently work due to the departures endpoint [(correctly)](https://github.com/jpsingleton/Huxley2/issues/12#issuecomment-1159219142) returning null. Likewise after #5 is merged the subsequent calls filter won't work for the arrivals only board.

To resolve this issue could we do something like only calling the all endpoint and filtering the results ourselves depending on which board was being viewed?